### PR TITLE
v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,31 @@
+# v1.5.0 (Aug 15, 2019)
+
+ * chore: Added Appc Daemon v3 to list of compatible appcd versions.
+ * chore: Update dependencies.
+
 # v1.4.0 (Jun 6, 2019)
 
- * Updated config to remove redundant `windows` namespace.
+ * fix: Updated config to remove redundant `windows` namespace.
  * chore: Switched `prepare` script to `prepack`.
 
 # v1.3.0 (Mar 29, 2019)
 
- * Upgraded to Gulp 4.
- * Update dependencies
- * Refactored promises to use async/await.
+ * chore: Upgraded to Gulp 4.
+ * chore: Update dependencies.
+ * refactor: Refactored promises to use async/await.
 
 # v1.2.0 (Oct 25, 2018)
 
- * Moved to `@appcd` scope
- * Update dependencies
- * Add Daemon 2.x support
+ * chore: Moved to `@appcd` scope
+ * chore: Update dependencies
+ * feat: Add Daemon 2.x support
 
 # v1.1.0 (Apr 9, 2018)
 
- * Removed `appcd-*` dependencies and locked down the appcd version in the `package.json`.
+ * fix: Removed `appcd-*` dependencies and locked down the appcd version in the `package.json`.
    [(DAEMON-208)](https://jira.appcelerator.org/browse/DAEMON-208)
- * Fixed URLs in `package.json`.
- * Updated npm dependencies.
+ * fix: Fixed URLs in `package.json`.
+ * chore: Updated dependencies.
 
 # v1.0.0 (Dec 5, 2017)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-windows",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Windows service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,19 +16,19 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.6.2",
-    "source-map-support": "^0.5.11",
-    "windowslib": "^0.6.8"
+    "gawk": "^4.6.4",
+    "source-map-support": "^0.5.13",
+    "windowslib": "^0.6.9"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.1.0",
-    "gulp": "^4.0.0"
+    "appcd-gulp": "^2.2.0",
+    "gulp": "^4.0.2"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon-plugins/tree/master/packages/appcd-plugin-windows",
   "bugs": "https://github.com/appcelerator/appc-daemon-plugins/issues",
   "repository": "https://github.com/appcelerator/appc-daemon-plugins",
   "appcd": {
-    "appcdVersion": "1.x || 2.x",
+    "appcdVersion": "1.x || 2.x || 3.x",
     "config": "./conf/config.js",
     "name": "windows",
     "os": [


### PR DESCRIPTION
chore: Added Appc Daemon v3 to list of compatible appcd versions.
chore: Update dependencies.