### PR TITLE
v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.5.3 (Jun 8, 2020)
+
+ * chore: Added API version 2.x.
+ * chore: Transpile for Node 10 instead of Node 8. Not a breaking change as appcd has always
+   guaranteed Node 10 or newer.
+ * chore: Updated dependencies.
+
 # v1.5.2 (Jan 9, 2020)
 
  * chore: Switched to new `appcd.apiVersion`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appcd/plugin-windows",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Windows service for the Appc Daemon.",
   "main": "./dist/index",
   "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
@@ -16,18 +16,18 @@
     "test": "gulp test"
   },
   "dependencies": {
-    "gawk": "^4.7.0",
-    "source-map-support": "^0.5.16",
+    "gawk": "^4.7.1",
+    "source-map-support": "^0.5.19",
     "windowslib": "^0.6.9"
   },
   "devDependencies": {
-    "appcd-gulp": "^2.3.1"
+    "appcd-gulp": "^3.0.0"
   },
   "homepage": "https://github.com/appcelerator/appc-daemon-plugins/tree/master/packages/appcd-plugin-windows",
   "bugs": "https://github.com/appcelerator/appc-daemon-plugins/issues",
   "repository": "https://github.com/appcelerator/appc-daemon-plugins",
   "appcd": {
-    "apiVersion": "1.x",
+    "apiVersion": "1.x || 2.x",
     "config": "./conf/config.js",
     "name": "windows",
     "os": [


### PR DESCRIPTION
 * chore: Added API version 2.x.
 * chore: Transpile for Node 10 instead of Node 8. Not a breaking change as appcd has always guaranteed Node 10 or newer.
 * chore: Updated dependencies.